### PR TITLE
Add ECR public to default AWS mapping

### DIFF
--- a/mappings/aws.yml
+++ b/mappings/aws.yml
@@ -1,3 +1,4 @@
 helper: ecr-login
 domains:
   - amazonaws.com
+  - ecr.aws


### PR DESCRIPTION
By default will authenticate to public ECR repos which will help with increased limits.

https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html